### PR TITLE
Fix start action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,11 +12,12 @@ runs:
   steps:
   - shell: bash
     run: |
+      export RUNNER_ID=$(id -u runner)
       docker pull aquasec/tracee:latest
       docker run -d --name tracee-profiler --rm --privileged \
       -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
       -v /proc:/proc -v /boot:/boot -v /lib/modules/:/lib/modules/:ro \
       -v /usr/src:/usr/src:ro -v ${{ inputs.workdir }}:/tmp/tracee aquasec/tracee:latest \
-      trace --trace event=execve --capture exec --capture profile
+      trace --trace event=execve -trace uid=$RUNNER_ID --capture exec --capture profile
 
       ${{ github.action_path }}/start.sh ${{ inputs.workdir }}

--- a/action.yaml
+++ b/action.yaml
@@ -12,10 +12,11 @@ runs:
   steps:
   - shell: bash
     run: |
-      docker pull simar7/tracee:latest
+      docker pull aquasec/tracee:latest
       docker run -d --name tracee-profiler --rm --privileged \
+      -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
       -v /proc:/proc -v /boot:/boot -v /lib/modules/:/lib/modules/:ro \
-      -v /usr/src:/usr/src:ro -v ${{ inputs.workdir }}:/tmp/tracee simar7/tracee:latest \
+      -v /usr/src:/usr/src:ro -v ${{ inputs.workdir }}:/tmp/tracee aquasec/tracee:latest \
       trace --trace event=execve --capture exec --capture profile
 
       ${{ github.action_path }}/start.sh ${{ inputs.workdir }}


### PR DESCRIPTION
This PR updates the image to use tracee latest. Also adds a scope to the profile, the github action runs the steps with the user `runner`, this allow us to ignore the noisy of the host, and only profile the actions of the build. 