### PR TITLE
fix example, move tracee to be the first command

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-
     - name: Start Tracee profiling in background
       uses: aquasecurity/tracee-action@v0.1.0-start
+
+    - uses: actions/checkout@v2
 
     - name: Your CI Pipeline Step
       run: for i in {1..20}; do sleep 2; done

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-
     - name: Start Tracee profiling in background
       uses: aquasecurity/tracee-action@v0.1.0-start
+
+    - uses: actions/checkout@v2
 
     - name: Your CI Pipeline Step
       run: for i in {1..20}; do sleep 2; done


### PR DESCRIPTION
Tracee should be the first and last actions to it monitor everything on the build. 