### PR TITLE
feat: add runtime dropped executable signature

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,7 @@ runs:
       docker run -d --name tracee --rm \
       --privileged --pid=host --cgroupns=host \
       -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
+      -v ${{github.action_path}}/signatures/runtime_dropped_executable.rego:/tracee/rules/runtime_dropped_executable.rego \
       -v /proc:/proc \
       -v /boot:/boot \
       -v /lib/modules/:/lib/modules/:ro \
@@ -20,7 +21,7 @@ runs:
       --entrypoint=/tracee/tracee \
       aquasec/tracee:0.10.0 \
       --trace uid=$RUNNER_ID  \
-      --trace event=stdio_over_socket,aslr_inspection,proc_mem_code_injection,docker_abuse,scheduled_task_mod,ld_preload,cgroup_notify_on_release,default_loader_mod,sudoers_modification,sched_debug_recon,system_request_key_mod,cgroup_release_agent,rcd_modification,core_pattern_modification,proc_kcore_read,proc_mem_access,hidden_file_created,anti_debugging,ptrace_code_injection,process_vm_write_inject,disk_mount,dynamic_code_loading,fileless_execution,illegitimate_shell,kernel_module_loading,proc_fops_hooking,syscall_hooking,dropped_executable \
+      --trace event=stdio_over_socket,aslr_inspection,proc_mem_code_injection,docker_abuse,scheduled_task_mod,ld_preload,cgroup_notify_on_release,default_loader_mod,sudoers_modification,sched_debug_recon,system_request_key_mod,cgroup_release_agent,rcd_modification,core_pattern_modification,proc_kcore_read,proc_mem_access,hidden_file_created,anti_debugging,ptrace_code_injection,process_vm_write_inject,disk_mount,dynamic_code_loading,fileless_execution,illegitimate_shell,kernel_module_loading,proc_fops_hooking,syscall_hooking,runtime_dropped_executable \
       --trace event=sched_process_exec,net_packet_dns \
       --output option:exec-hash --output option:exec-env \
       --output out-file:/tmp/tracee/out/trace_$GITHUB_RUN_ID.jsonl --output format:json

--- a/signatures/runtime_dropped_executable.rego
+++ b/signatures/runtime_dropped_executable.rego
@@ -1,0 +1,36 @@
+package tracee.TRC_9
+
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+	"id": "TRC-1000",
+	"version": "0.1.0",
+	"name": "New Executable Was Dropped During Runtime",
+	"eventName": "runtime_dropped_executable",
+	"description": "An Executable file was dropped in your system during runtime.",
+	"tags": ["linux", "container"],
+	"properties": {
+		"Severity": 2,
+		"MITRE ATT&CK": "Defense Evasion: Masquerading",
+	},
+}
+
+eventSelectors := [{
+	"source": "tracee",
+	"name": "magic_write",
+	"origin": "*",
+}]
+
+tracee_selected_events[eventSelector] {
+	eventSelector := eventSelectors[_]
+}
+
+tracee_match = res {
+	input.eventName == "magic_write"
+
+	file_header := helpers.get_tracee_argument("bytes")
+	helpers.is_elf_file(file_header)
+
+	pathname := helpers.get_tracee_argument("pathname")
+	res := {"file path": pathname}
+}


### PR DESCRIPTION
Add new signature to detect dropped executable in the host, not only containers. 
Example of the action https://github.com/josedonizetti/verified-build-tests/pull/67 tested with a trigger to catch:
```
curl -LO https://github.com/kubernetes/minikube/releases/download/v1.28.0/minikube-linux-amd64
```