### PR TITLE
feat: scope by runner listener process tree

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
   - shell: bash
     run: |
-      RUNNER_ID=$(id -u runner)
+      runner_pid=$(pgrep Runner.Listener)
       docker pull aquasec/tracee:0.10.0
       docker run -d --name tracee --rm \
       --privileged --pid=host --cgroupns=host \
@@ -19,7 +19,7 @@ runs:
       -v /usr/src:/usr/src:ro \
       --entrypoint=/tracee/tracee \
       aquasec/tracee:0.10.0 \
-      --trace uid=$RUNNER_ID  \
+      --trace tree=$runner_pid \
       --trace event=stdio_over_socket,aslr_inspection,proc_mem_code_injection,docker_abuse,scheduled_task_mod,ld_preload,cgroup_notify_on_release,default_loader_mod,sudoers_modification,sched_debug_recon,system_request_key_mod,cgroup_release_agent,rcd_modification,core_pattern_modification,proc_kcore_read,proc_mem_access,hidden_file_created,anti_debugging,ptrace_code_injection,process_vm_write_inject,disk_mount,dynamic_code_loading,fileless_execution,illegitimate_shell,kernel_module_loading,proc_fops_hooking,syscall_hooking,dropped_executable \
       --trace event=sched_process_exec,net_packet_dns \
       --output option:exec-hash --output option:exec-env \


### PR DESCRIPTION
scope by the runner listener process tree in order to see executions like `sudo curl --head http://aquasecurity.com`, which will be part of the tree, but because of `sudo` will use `root` user instead of `runner. 

example of action using: https://github.com/josedonizetti/verified-build-tests/pull/71
example of profile generated: https://github.com/josedonizetti/verified-build-tests/pull/72