### PR TITLE
feat: trace file writes (for writes profile)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,10 +18,11 @@ runs:
       -v /tmp/tracee/:/tmp/tracee \
       -v /usr/src:/usr/src:ro \
       --entrypoint=/tracee/tracee \
+      -v ${{github.action_path}}/signatures/file_write.rego:/tracee/rules/file_write.rego \
       aquasec/tracee:0.10.0 \
       --trace tree=$runner_pid \
-      --trace event=stdio_over_socket,aslr_inspection,proc_mem_code_injection,docker_abuse,scheduled_task_mod,ld_preload,cgroup_notify_on_release,default_loader_mod,sudoers_modification,sched_debug_recon,system_request_key_mod,cgroup_release_agent,rcd_modification,core_pattern_modification,proc_kcore_read,proc_mem_access,hidden_file_created,anti_debugging,ptrace_code_injection,process_vm_write_inject,disk_mount,dynamic_code_loading,fileless_execution,illegitimate_shell,kernel_module_loading,proc_fops_hooking,syscall_hooking,dropped_executable \
-      --trace event=sched_process_exec,net_packet_dns \
+      --trace event=stdio_over_socket,aslr_inspection,proc_mem_code_injection,docker_abuse,scheduled_task_mod,ld_preload,cgroup_notify_on_release,default_loader_mod,sudoers_modification,sched_debug_recon,system_request_key_mod,cgroup_release_agent,rcd_modification,core_pattern_modification,proc_kcore_read,proc_mem_access,hidden_file_created,anti_debugging,ptrace_code_injection,process_vm_write_inject,disk_mount,dynamic_code_loading,fileless_execution,illegitimate_shell,kernel_module_loading,proc_fops_hooking,syscall_hooking,dropped_executable,file_write \
+      --trace event=sched_process_exec,net_packet_dns --trace security_file_open.args.pathname="${{github.workspace}}/*" \
       --output option:exec-hash --output option:exec-env \
       --output out-file:/tmp/tracee/out/trace_$GITHUB_RUN_ID.jsonl --output format:json
       echo -n "Waiting for Tracee to start..."

--- a/signatures/file_write.rego
+++ b/signatures/file_write.rego
@@ -1,0 +1,22 @@
+package tracee.TRC_1001
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+	"id": "TRC_1001",
+	"version": "0.1.0",
+	"name": "File write",
+	"eventName": "file_write",
+	"description": "A file is being written to",
+}
+
+tracee_selected_events[eventSelector] {
+	eventSelector := {
+		"source": "tracee",
+		"name": "security_file_open",
+	}
+}
+
+tracee_match {
+	input.eventName == "security_file_open"
+  helpers.is_file_write(helpers.get_tracee_argument("flags"))
+}


### PR DESCRIPTION
note that this scopes security_file_open for the code directory only,
and therefore will break the signatures that rely on the unfiltered event.
such as:
aslr_inspection,cgroup_notify_on_release,cgroup_release_agent,
core_pattern_modification,default_loader_mod,docker_abuse,ld_preload,
proc_kcore_read,proc_mem_access,proc_mem_code_injection,rcd_modification,
sched_debug_recon,scheduled_task_mod,sudoers_modification,
system_request_key_mod