### PR TITLE
fix: create comment only if pr

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,13 @@ runs:
     run: |
       echo "Checking if signatures were triggered..."
       if [[ -s /tmp/tracee-action/signatures.jsonl ]]; then
-       ${{github.action_path}}/create-pr-comment.sh
+        if ${{ github.event_name == 'pull_request' }}; then
+          echo "Creating PR comment with triggered signatures"
+          ${{github.action_path}}/create-pr-comment.sh ${{ github.token }}
+        else
+          echo "Printing triggered signatures"
+          cat /tmp/tracee-action/signatures.jsonl  
+        fi
       fi
   - shell: bash
     run: |

--- a/create-pr-comment.sh
+++ b/create-pr-comment.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -o pipefail
+
+token="$1"
+
+gh auth login --with-token <<<"$token"
 
 pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 comment=$(cat <<EOF


### PR DESCRIPTION
Fixes signatures flow. Only comment on PR if the event triggering it was a PR. Stop expecting GITHUB_TOKEN.