### PR TITLE
feat: add dns discard list

### DIFF
--- a/profile/dns.jq
+++ b/profile/dns.jq
@@ -1,5 +1,7 @@
 def getarg(name): .args[] | select(.name == name) | .value;
 
+def discard_items(dns): if dns | length > 0 then map(select([startswith(dns[])] | any | not)) else . end;
+
 [
-  .[] | getarg("proto_dns").questions[].name
-] | unique
+  .[] | getarg("proto_dns").questions[].name 
+] | discard_items($config[0].dns_discard) | unique

--- a/profile/profile-config.json
+++ b/profile/profile-config.json
@@ -8,5 +8,8 @@
     "INVOCATION_ID",
     "JOURNAL_STREAM",
     "GITHUB_"
-  ]
+	],
+	"dns_discard": [
+		"pipelines.actions.githubusercontent.com"
+	]
 }


### PR DESCRIPTION
The github dns `pipelines.actions.githubusercontent.com` sometimes will be resolved during the pipeline, sometimes not, leading to an unstable `profile-dns.json`. This could also be true for users, with if conditions on the pipeline where at sometimes a DNS will be resolved, and sometimes not, so it is best we support discard like we do for exec, and writes. 