### PR TITLE
add binary_sha discard

### DIFF
--- a/profile/exec.jq
+++ b/profile/exec.jq
@@ -7,6 +7,9 @@ def discard_items(patterns): if patterns | length > 0 then map(select([test(patt
 # discard_items_pairs discards all pairs of items in the input array of strings that the first element in the pair matches any of the regular expressions in the patterns array of strings
 def discard_items_pairs(patterns): if patterns | length > 0 then delpaths([paths([test(patterns[])] | any) | .,map(.+1)]) else . end;
 
+# discard_binary_sha256 discards all process where the sha matches the input array of strings
+def discard_binary_sha256(patterns): if patterns | length > 0 then select([.binary_sha256 | contains(patterns[])] | any | not) else . end;
+
 [
   .[] | 
   { 
@@ -16,5 +19,5 @@ def discard_items_pairs(patterns): if patterns | length > 0 then delpaths([paths
     binary_sha256: getarg("sha256"),
     process_args: getarg("argv") | discard_items_pairs($config[0].args_discard_pair) | discard_items($config[0].args_discard),
     process_env: (if isempty(getarg("env")) | not then (discard_items($config[0].env_discard) | sort) else null end)
-  } 
+  } | discard_binary_sha256($config[0].binary_sha256_discard)
 ] | sort_by(.binary_path)

--- a/profile/profile-config.json
+++ b/profile/profile-config.json
@@ -13,5 +13,7 @@
   ],
 	"dns_discard": [
 		"pipelines.actions.githubusercontent.com"
+	],
+	"binary_sha256_discard":[
 	]
 }


### PR DESCRIPTION
Allow discard by binaries due to conditional executions, and also temporary binaries, for example:

The path to this binary changes every build:
```
  {
    "user_id": 1001,
    "process_name": "build-tests.tes",
    "binary_path": "/tmp/go-build384123577/b001/build-tests.test",
    "binary_sha256": "d6785ef73341fc6da8e21e94203f2002cb304eae72643fbe5d1e1e7e97a9e9cc",
    "process_args": [
      "-test.paniconexit0",
      "-test.timeout=10m0s"
    ],
    "process_env": null
  },
```

This is sometimes executed, and sometimes not. 
```
 {
    "user_id": 1001,
    "process_name": "asm",
    "binary_path": "/opt/hostedtoolcache/go/1.18.10/x64/pkg/tool/linux_amd64/asm",
    "binary_sha256": "7b84d894a4d62bab25ddef9a1424d828cb50b3aa3e1ddd66a075acbeb7739631",
    "process_args": [
      "/opt/hostedtoolcache/go/1.18.10/x64/pkg/tool/linux_amd64/asm",
      "-V=full"
    ],
    "process_env": null
  },
```