### PR TITLE
fix pr comment when large comments

### DIFF
--- a/create-pr-comment.sh
+++ b/create-pr-comment.sh
@@ -18,4 +18,6 @@ $(cat /tmp/tracee-action/signatures.jsonl)
 \`\`\`
 EOF
 )
+
+comment=${comment:0:65536}
 gh pr comment $pull_number -b "$comment"


### PR DESCRIPTION
If the comment is too big we fail, so we are limiting the size of the comment by what is allowed on the gh api