### PR TITLE
temporarily disabling dynamic_code_loading

### DIFF
--- a/policies/signatures.yaml
+++ b/policies/signatures.yaml
@@ -29,7 +29,6 @@ spec:
     - event: ptrace_code_injection
     - event: process_vm_write_inject
     - event: disk_mount
-    - event: dynamic_code_loading
     - event: fileless_execution
     - event: illegitimate_shell
     - event: kernel_module_loading


### PR DESCRIPTION
the signature is too noisy, needs investigation before we enable it again