### PR TITLE
fix: broken link in md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tracee-action offers two kinds of protection that complements each other: Events
 
 Tracee runs in the background and hunts for suspicious behavior in the runner and in the workflow. It uses the powerful set of behavioral signatures that is available for Tracee, and you can add your own specific signatures to detect unwanted behavior.
 Signatures detections are reported to you as a comment on the PR that triggered the action for your review.
-You can review the list of events in the default policy [here](policies/signatures.yaml)
+You can review the list of events in the default policy [here](policies/signatures.yaml.tmpl)
 
 ### Profile
 


### PR DESCRIPTION
fix to the link to the default signature events